### PR TITLE
docs: add syntax highlighting to README.md code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # How to use
 
-```
+```js
 import { SnapshotCreator } from 'eslint-snapshot-tester';
 import { semi } from 'eslint/rules/semi';
 


### PR DESCRIPTION
👋 I just came across this project from https://github.com/typescript-eslint/typescript-eslint/discussions/6499. Really nice utility!

Reading the README.md is a bit painful without syntax highlighting though. Adding a `js` language indicator gets nicer syntax highlighting in Markdown viewers such as github.com. Cheers!
